### PR TITLE
A CLI utility for showing the general load timeline for a trace

### DIFF
--- a/bin/timeline
+++ b/bin/timeline
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+'use strict';
+
+const program = require('commander');
+const fs = require('fs');
+
+program
+  .command('find <tracefile> <url>')
+  .description('search for frame id by url')
+  .action(function(tracefile, url) {
+    const frame = findFrame(loadTrace(tracefile), url);
+    if (frame) console.log(frame);
+    else console.log('not found');
+  });
+
+program
+  .command('list <tracefile>')
+  .description('list main frame loads')
+  .action(function(tracefile) {
+    loadTrace(tracefile)
+      .filter(isCommitLoad)
+      .forEach(({ args: { data: { frame, url } } }) => {
+        console.log('frame %s url %s', frame, url);
+      });
+  });
+
+program
+  .command('show <tracefile> <frameOrURL>')
+  .option('-m, --marks', 'show user timing marks')
+  .option('-f, --filter [filter]', 'user timing marks start with', collect, [])
+  .action(function(tracefile, frameOrURL, options) {
+    const events = loadTrace(tracefile);
+    let frame;
+    if (frameOrURL.startsWith('http')) {
+      frame = findFrame(events, frameOrURL);
+    } else {
+      frame = frameOrURL;
+    }
+    if (!frame) {
+      console.log('not found');
+      return;
+    }
+    let startTime = -1;
+    events
+      .filter(event => isMark(event) || isCommitLoad(event))
+      .sort(byTime)
+      .forEach(event => {
+        if (isFrameNavigationStart(frame, event)) {
+          startTime = event.ts;
+          console.log(`${format(event.ts, startTime)} ${event.name}`);
+        } else if (isFrameMark(frame, event)) {
+          if (startTime === -1) {
+            startTime = event.ts;
+          }
+          console.log(`${format(event.ts, startTime)} ${event.name}`);
+        } else if (isUserMark(event) && options.marks) {
+          if (
+            options.filter.length === 0 ||
+            options.filter.some(f => event.name.indexOf(f) !== -1)
+          ) {
+            console.log(`${format(event.ts, startTime)} ${event.name}`);
+          }
+        } else if (isCommitLoad(event)) {
+          const { data } = event.args;
+          if (data.frame === frame) {
+            console.log(`${format(event.ts, startTime)} ${event.name} ${data.frame} ${data.url}`);
+          }
+        }
+      });
+  });
+
+if (process.argv.length === 2) {
+  program.help();
+}
+
+program.parse(process.argv);
+
+function collect(val, memo) {
+  memo.push(val);
+  return memo;
+}
+
+function format(ts, start) {
+  let ms = (ts - start) / 1000;
+  ms = '' + ms.toFixed(2);
+  while (ms.length < 10) {
+    ms = ' ' + ms;
+  }
+  return ms + 'ms';
+}
+
+function loadTrace(file) {
+  let events = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (!Array.isArray(events)) events = events.traceEvents;
+  return events;
+}
+
+function isMark(event) {
+  return event.ph === 'R';
+}
+
+function isFrameMark(frame, event) {
+  return event.ph === 'R' && event.args.frame === frame;
+}
+
+function isFrameNavigationStart(frame, event) {
+  return isFrameMark(frame, event) && event.name === 'navigationStart';
+}
+
+function isUserMark(event) {
+  return (
+    event.ph === 'R' && event.cat === 'blink.user_timing' && Object.keys(event.args).length === 0
+  );
+}
+
+function isCommitLoad(event) {
+  return (
+    event.ph === 'X' &&
+    event.name === 'CommitLoad' &&
+    event.args.data !== undefined &&
+    event.args.data.isMainFrame
+  );
+}
+
+function byTime(a, b) {
+  return a.ts - b.ts;
+}
+
+function findFrame(events, url) {
+  const event = events.filter(isCommitLoad).find(event => event.args.data.url.startsWith(url));
+  if (event) {
+    return event.args.data.frame;
+  }
+  return null;
+}


### PR DESCRIPTION
Show a timeline for the trace for the given frame
`./bin/timeline show trace.json 0x3c206a1df8`

Show a timeline for the trace for the first main frame matching this url
and show user performance.marks that match the given filters
`bin/timeline show trace.json https://www.linkedin.com -m -f mark_bigpipe -f render_end`

show a list of main frame ids and their urls
`bin/timeline list trace.json`

Find the first frame id for the given url
`bin/timeline find trace.json https://www.linkedin.com`