### PR TITLE
Expand collapsed trace file into a full profile

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,7 +1,7 @@
-// tslint:disable:member-ordering
-
+import { HierarchyNode } from 'd3-hierarchy';
 import * as fs from 'fs';
-import { Trace } from '../trace';
+import { ICpuProfileNode, Trace } from '../trace';
+import { exportHierarchy } from '../trace/export';
 import { aggregate, categorizeAggregations, collapseCallFrames, verifyMethods } from './aggregator';
 import { Archive } from './archive_trace';
 import { ModuleMatcher } from './module_matcher';
@@ -43,6 +43,29 @@ export default class CommandLine {
     this.filePath = file || defaultProfilePath;
   }
 
+  run() {
+    let { archive } = this;
+    let { report, methods } = this.ui;
+    let trace = this.loadTrace();
+    let profile = this.cpuProfile(trace)!;
+
+    // Uncomment this if you want the hirearchy outputted as X events into a copy
+    // of the input trace file. This feature will get formally integrated later.
+    // this.export(profile.hierarchy, trace);
+
+    let modMatcher = new ModuleMatcher(profile.hierarchy, archive);
+
+    let categories = formatCategories(report, methods);
+    let allMethods = methodsFromCategories(categories);
+    addRemainingModules(allMethods, categories, modMatcher);
+    verifyMethods(allMethods);
+
+    let aggregations = aggregate(profile.hierarchy, allMethods, archive, modMatcher);
+    let collapsed = collapseCallFrames(aggregations);
+    let categorized = categorizeAggregations(collapsed, categories);
+    reporter(categorized);
+  }
+
   private loadTrace() {
     let { filePath } = this;
     let traceEvents = JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -58,22 +81,9 @@ export default class CommandLine {
     return trace.cpuProfile(min, max);
   }
 
-  run() {
-    let { archive } = this;
-    let { report, methods } = this.ui;
-    let trace = this.loadTrace();
-    let profile = this.cpuProfile(trace)!;
-
-    let modMatcher = new ModuleMatcher(profile.hierarchy, archive);
-
-    let categories = formatCategories(report, methods);
-    let allMethods = methodsFromCategories(categories);
-    addRemainingModules(allMethods, categories, modMatcher);
-    verifyMethods(allMethods);
-
-    let aggregations = aggregate(profile.hierarchy, allMethods, archive, modMatcher);
-    let collapsed = collapseCallFrames(aggregations);
-    let categorized = categorizeAggregations(collapsed, categories);
-    reporter(categorized);
+  private export(hierarchy: HierarchyNode<ICpuProfileNode>, trace: Trace) {
+    const { filePath } = this;
+    const rawTraceData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    exportHierarchy(rawTraceData, hierarchy, trace, filePath);
   }
 }

--- a/src/trace/cpuprofile.ts
+++ b/src/trace/cpuprofile.ts
@@ -1,5 +1,15 @@
 import { hierarchy, HierarchyNode } from 'd3-hierarchy';
-import { FUNCTION_NAME, ICpuProfile, ICpuProfileNode, ISample } from './trace_event';
+import {
+  FUNCTION_NAME,
+  ICpuProfile,
+  ICpuProfileEvent,
+  ICpuProfileNode,
+  IProfileNode,
+  ISample,
+  ITraceEvent,
+  TRACE_EVENT_NAME,
+  TRACE_EVENT_PHASE,
+} from './trace_event';
 
 export default class CpuProfile {
   profile: ICpuProfile;
@@ -7,7 +17,7 @@ export default class CpuProfile {
   /**
    * Node by node id.
    */
-  nodes: Map<number, ICpuProfileNode>;
+  nodeMap: Map<number, ICpuProfileNode>;
 
   samples: ISample[];
 
@@ -15,21 +25,6 @@ export default class CpuProfile {
    * Root parent
    */
   root?: ICpuProfileNode;
-
-  /**
-   * Program node
-   */
-  program?: ICpuProfileNode;
-
-  /**
-   * Idle node
-   */
-  idle?: ICpuProfileNode;
-
-  /**
-   * GC node
-   */
-  gc?: ICpuProfileNode;
 
   start: number;
   end: number;
@@ -40,59 +35,42 @@ export default class CpuProfile {
   private parentLinks: Map<ICpuProfileNode, ICpuProfileNode>;
   private childrenLinks: Map<ICpuProfileNode, ICpuProfileNode[]>;
 
-  constructor(profile: ICpuProfile, min: number, max: number) {
+  constructor(profile: ICpuProfile, events: ITraceEvent[], min: number, max: number) {
     this.profile = profile;
 
     const parentLinks = (this.parentLinks = new Map<ICpuProfileNode, ICpuProfileNode>());
     const childrenLinks = (this.childrenLinks = new Map<ICpuProfileNode, ICpuProfileNode[]>());
 
     const nodes = profile.nodes;
+    initNodes(nodes);
+    const nodeMap = mapAndLinkNodes(nodes, parentLinks, childrenLinks);
 
-    const nodeMap = (this.nodes = mapAndLinkNodes(nodes, parentLinks, childrenLinks));
+    const originalRoot: ICpuProfileNode | undefined = nodes.find(node => {
+      return node.callFrame.scriptId === 0 || node.callFrame.scriptId === '0' &&
+             node.callFrame.functionName === FUNCTION_NAME.ROOT;
+    });
+    if (originalRoot === undefined) throw new Error('Missing root node in original profile');
 
-    let root: ICpuProfileNode | undefined;
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
-
-      if (node.callFrame.scriptId === 0 || node.callFrame.scriptId === '0') {
-        switch (node.callFrame.functionName) {
-          case FUNCTION_NAME.ROOT:
-            root = node;
-            break;
-          case FUNCTION_NAME.PROGRAM:
-            this.program = node;
-            break;
-          case FUNCTION_NAME.IDLE:
-            this.idle = node;
-            break;
-          case FUNCTION_NAME.GC:
-            this.gc = node;
-            break;
-        }
-      }
-    }
-
-    this.samples = mapSamples(profile, nodeMap, min, max);
-
-    if (root === undefined) {
-      throw new Error('missing root node in profile');
-    }
-
-    this.root = root;
-
-    computeTimes(root, childrenLinks);
+    this.samples = absoluteSamples(profile, nodeMap);
+    const {expandedRoot, expandedNodeMap} = expandAndFix(this.samples, profile, events,
+                                               min, max, parentLinks, childrenLinks, originalRoot);
+    this.root = expandedRoot;
+    this.nodeMap = expandedNodeMap;
 
     const start = (this.start = profile.startTime);
-    const end = (this.end = root.max);
+    const end = (this.end = expandedRoot.max);
     this.duration = end - start;
 
-    this.hierarchy = hierarchy(root, node => {
+    this.hierarchy = hierarchy(expandedRoot, node => {
       const children = childrenLinks.get(node);
       if (children) {
-        return root === node ? children.filter(n => !isMetaNode(n)) : children;
+        return expandedRoot === node ? children.filter(n => !isMetaNode(n)) : children;
       }
       return null;
     });
+
+    // Make child iteration easier
+    this.hierarchy.each(node => { if (node.children === undefined) node.children = []; });
   }
 
   parent(node: ICpuProfileNode) {
@@ -104,9 +82,47 @@ export default class CpuProfile {
   }
 
   node(id: number) {
-    const n = this.nodes.get(id);
+    const n = this.nodeMap.get(id);
     if (n === undefined) throw new Error(`invalid node id: ${id}`);
     return n;
+  }
+}
+
+function expandAndFix(
+  samples: ISample[],
+  profile: ICpuProfile,
+  events: ITraceEvent[],
+  min: number,
+  max: number,
+  parentLinks: Map<ICpuProfileNode, ICpuProfileNode>,
+  childrenLinks: Map<ICpuProfileNode, ICpuProfileNode[]>,
+  root: ICpuProfileNode,
+) {
+  const {expandedNodes, orig2ExpNodes} = expandNodes(samples, profile, events, min, max, parentLinks);
+  profile.nodes = expandedNodes;
+  parentLinks.clear();
+  childrenLinks.clear();
+
+  const expandedNodeMap = mapAndLinkNodes(expandedNodes, parentLinks, childrenLinks);
+
+  if (! orig2ExpNodes.has(root.id)) throw new Error('Missing root node in expanded profile');
+  return {expandedRoot: orig2ExpNodes.get(root.id)![0], expandedNodeMap};
+}
+
+function isCpuProfile(traceEvent: ITraceEvent | undefined): traceEvent is ICpuProfileEvent {
+  return traceEvent !== undefined && traceEvent.ph === 'I' && traceEvent.name === 'CpuProfile';
+}
+
+function initNodes(
+  nodes: ICpuProfileNode[],
+) {
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    // initialize our extensions
+    node.min = -1;
+    node.max = -1;
+    node.sampleCount = 0;
+    node.self = 0;
   }
 }
 
@@ -117,13 +133,7 @@ function mapAndLinkNodes(
 ) {
   const nodeMap = new Map<number, ICpuProfileNode>();
   for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
-    // initialize our extensions
-    node.min = -1;
-    node.max = -1;
-    node.sampleCount = 0;
-    node.self = 0;
-    nodeMap.set(node.id, node);
+    nodeMap.set(nodes[i].id, nodes[i]);
   }
 
   linkNodes(nodes, nodeMap, parentLinks, childrenLinks);
@@ -160,11 +170,9 @@ function linkChildren(
   childrenLinks.set(parent, children);
 }
 
-function mapSamples(
+function absoluteSamples(
   profile: ICpuProfile,
   nodeMap: Map<number, ICpuProfileNode>,
-  min: number,
-  max: number,
 ) {
   const sampleIds = profile.samples;
   const samples: ISample[] = new Array(sampleIds.length);
@@ -201,24 +209,210 @@ function mapSamples(
       sample.delta = timestamp - prev.timestamp;
       sample.prev = prev;
     }
-
-    if (min < timestamp && (max > timestamp || max === -1)) {
-      const node = sample.node;
-      if (node.min === -1) {
-        node.min = timestamp;
-      }
-
-      node.self += sample.delta;
-      node.max = timestamp;
-    }
-
     prev = sample;
   }
 
   return samples;
 }
 
-function computeTimes(node: ICpuProfileNode, childrenMap: Map<ICpuProfileNode, ICpuProfileNode[]>) {
+function expandNodes(
+  samples: ISample[],
+  profile: ICpuProfile,
+  events: ITraceEvent[],
+  min: number,
+  max: number,
+  parentLinks: Map<ICpuProfileNode, ICpuProfileNode>,
+) {
+  const expandedNodes: ICpuProfileNode[] = [];
+  const orig2ExpNodes = new Map<number, ICpuProfileNode[]>();
+  const stack: ICpuProfileNode[] = [];
+  const state: ExpState = {
+    isExecuting: false,
+    lastSampleTS: -1,
+    stack: [],
+    origId2activeIndex: new Map<number, number>(),
+    expId2origId: new Map<number, number>(),
+  };
+
+  let i = 0;
+  let j = 0;
+
+  for (; i < samples.length && j < events.length;) {
+    if (samples[i].timestamp <= events[j].ts) {
+      if (!isOutOfBounds(samples[i].timestamp, min, max) && state.isExecuting) {
+        processSample(samples[i], orig2ExpNodes, parentLinks, expandedNodes, state);
+      }
+      i++;
+    } else {
+      if (!isOutOfBounds(events[j].ts, min, max)) {
+        processEvent(events[j], orig2ExpNodes, parentLinks, expandedNodes, state);
+      }
+      j++;
+    }
+  }
+
+  for (; i < samples.length; i++) {
+    if (!isOutOfBounds(samples[i].timestamp, min, max) && state.isExecuting) {
+      processSample(samples[i], orig2ExpNodes, parentLinks, expandedNodes, state);
+    }
+  }
+
+  for (; j < events.length; j++) {
+    if (!isOutOfBounds(events[j].ts, min, max)) {
+      processEvent(events[j], orig2ExpNodes, parentLinks, expandedNodes, state);
+    }
+  }
+
+  return {expandedNodes, orig2ExpNodes};
+}
+
+function isOutOfBounds(ts: number, min: number, max: number) {
+  return ts < min || (max !== -1 && ts > max);
+}
+
+function terminateNodes(
+  toTerminate: ICpuProfileNode[],
+  ts: number,
+  state: ExpState,
+) {
+  toTerminate.forEach(node => {
+    state.origId2activeIndex.delete(state.expId2origId.get(node.id)!);
+    state.expId2origId.delete(node.id);
+    node.max = ts;
+  });
+}
+
+function activateNodes(
+  toActivate: ICpuProfileNode[],
+  state: ExpState,
+  ts: number,
+  newNodes: ICpuProfileNode[],
+  orig2ExpNodes: Map<number, ICpuProfileNode[]>,
+) {
+  const { stack, origId2activeIndex, expId2origId } = state;
+  let parent = stack[stack.length - 1];
+
+  for (let i = toActivate.length - 1; i >= 0; i--) {
+    const oldNode = toActivate[i];
+    // IProfileNode type gives access to the .parent attribute
+    const newNode: ICpuProfileNode & IProfileNode = JSON.parse(JSON.stringify(oldNode));
+    newNode.id = newNodes.length;
+
+    if (parent) {
+      newNode.parent = parent.id;
+
+      const children = parent.children;
+      if (children !== undefined) {
+        children.push(newNode.id);
+      } else {
+        parent.children = [newNode.id];
+      }
+    }
+
+    // clear out node-->children links
+    newNode.children = undefined;
+
+    newNode.min = ts;
+    newNode.max = -1;
+    newNode.self = 0;
+    newNode.total = 0;
+
+    newNodes.push(newNode);
+    stack.push(newNode);
+    origId2activeIndex.set(oldNode.id, stack.length - 1);
+    expId2origId.set(newNode.id, oldNode.id);
+    if (orig2ExpNodes.has(oldNode.id)) {
+      orig2ExpNodes.get(oldNode.id)!.push(newNode);
+    } else {
+      orig2ExpNodes.set(oldNode.id, [newNode]);
+    }
+
+    parent = newNode;
+  }
+}
+
+function addDurationToNodes(
+  stack: ICpuProfileNode[],
+  delta: number,
+) {
+  for (let i = 0; i < stack.length; i++) {
+    stack[i].total += delta;
+  }
+  if (stack.length > 0) stack[stack.length - 1].self += delta;
+}
+
+interface ExpState {
+  isExecuting: boolean;
+  lastSampleTS: number;
+  stack: ICpuProfileNode[];
+  origId2activeIndex: Map<number, number>;
+  expId2origId: Map<number, number>;
+}
+
+function processEvent(
+  event: ITraceEvent,
+  orig2ExpNodes: Map<number, ICpuProfileNode[]>,
+  parentLinks: Map<ICpuProfileNode, ICpuProfileNode>,
+  newNodes: ICpuProfileNode[],
+  state: ExpState,
+) {
+  const { stack, lastSampleTS } = state;
+  if (event.ph === TRACE_EVENT_PHASE.BEGIN) state.isExecuting = true;
+
+  if (event.ph === TRACE_EVENT_PHASE.END) {
+    if (event.name === TRACE_EVENT_NAME.V8_EXECUTE) {
+      addDurationToNodes(stack, event.ts - lastSampleTS);
+      const toTerminate = stack.splice(1); // don't slice (root)
+      terminateNodes(toTerminate, event.ts, state);
+      state.isExecuting = false;
+    }
+  }
+}
+
+function processSample(
+  sample: ISample,
+  orig2ExpNodes: Map<number, ICpuProfileNode[]>,
+  parentLinks: Map<ICpuProfileNode, ICpuProfileNode>,
+  newNodes: ICpuProfileNode[],
+  state: ExpState,
+) {
+  const { stack, origId2activeIndex } = state;
+  let curNode: ICpuProfileNode | undefined;
+  const toActivate: ICpuProfileNode[] = [];
+
+  state.lastSampleTS = sample.timestamp;
+
+  for (curNode = sample.node; curNode; curNode = parentLinks.get(curNode)) {
+    if (origId2activeIndex.has(curNode.id)) break;
+    toActivate.push(curNode);
+  }
+
+  addDurationToNodes(stack, sample.delta);
+
+  let spliceStart;
+  if (curNode === undefined) {
+    // No ongoing nodes, remove everything from the stack
+    spliceStart = 0;
+  } else {
+    // Don't let GC or Program samples terminate the current stack
+    if (sample.node.callFrame.functionName === FUNCTION_NAME.GC ||
+        sample.node.callFrame.functionName === FUNCTION_NAME.PROGRAM) {
+          spliceStart = stack.length; // no-op for slice
+    } else {
+      // Leave only ongoing nodes on the stack
+      spliceStart = origId2activeIndex.get(curNode.id)! + 1;
+    }
+  }
+  const toTerminate = stack.splice(spliceStart);
+
+  terminateNodes(toTerminate, sample.timestamp, state);
+  activateNodes(toActivate, state, sample.timestamp, newNodes, orig2ExpNodes);
+}
+
+function computeTimes(
+  node: ICpuProfileNode,
+  childrenMap: Map<ICpuProfileNode, ICpuProfileNode[]>,
+) {
   const children = childrenMap.get(node);
   let childTotal = 0;
   let min = node.min;

--- a/src/trace/export.ts
+++ b/src/trace/export.ts
@@ -1,0 +1,31 @@
+import { HierarchyNode } from 'd3-hierarchy';
+import * as fs from 'fs';
+import { ICpuProfileNode, ITraceEvent, Trace, TRACE_EVENT_NAME, TRACE_EVENT_PHASE } from '../trace';
+
+export function exportHierarchy(
+    rawTraceData: any,
+    hierarchy: HierarchyNode<ICpuProfileNode>,
+    trace: Trace,
+    filePath: string) {
+
+    const newTraceData = JSON.parse(JSON.stringify(rawTraceData));
+    const events: ITraceEvent[] = newTraceData.traceEvents;
+    hierarchy.each(node => {
+        const completeEvent: ITraceEvent = {
+            pid: trace.mainProcess!.id,
+            tid: trace.mainProcess!.mainThread!.id,
+            tdur: node.data.max - node.data.min,
+            ts: node.data.min,
+            ph: TRACE_EVENT_PHASE.COMPLETE,
+            cat: 'blink.user_timing',
+            name: node.data.callFrame.functionName,
+            args: {data: {functionName: node.data.callFrame.functionName}},
+            dur: node.data.max - node.data.min,
+        };
+
+        events.push(completeEvent);
+    });
+
+    const outputFilePath = filePath.endsWith('.json') ? filePath.slice(0, filePath.length - 5) : filePath;
+    fs.writeFileSync(`${outputFilePath}-processed.json`, JSON.stringify(newTraceData, null, ' '), 'utf8');
+}

--- a/src/trace/trace.ts
+++ b/src/trace/trace.ts
@@ -51,7 +51,7 @@ export default class Trace {
     if (_cpuProfile === undefined) {
       throw new Error('trace is missing CpuProfile');
     }
-    return new CpuProfile(_cpuProfile, min, max);
+    return new CpuProfile(_cpuProfile, this.events, min, max);
   }
 
   process(pid: number): Process {
@@ -167,7 +167,7 @@ export default class Trace {
   }
 
   getParent(event: ITraceEvent) {
-    this.parents.get(event);
+    return this.parents.get(event);
   }
 
   private associateParent(event: ITraceEvent) {
@@ -264,7 +264,7 @@ export default class Trace {
     };
     const { events } = this;
     const index = binsearch(events, begin, traceEventComparator);
-    events[index] = complete;
+    events.splice(index, 0, complete);
   }
 
   private addMetadata(event: ITraceEvent) {

--- a/src/trace/trace_event.ts
+++ b/src/trace/trace_event.ts
@@ -38,6 +38,7 @@ export const enum TRACE_EVENT_NAME {
   PROFILE = 'Profile',
   PROFILE_CHUNK = 'ProfileChunk',
   CPU_PROFILE = 'CpuProfile',
+  V8_EXECUTE = 'V8.Execute',
 }
 
 export const enum PROCESS_NAME {

--- a/tests/aggregator-test.ts
+++ b/tests/aggregator-test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from 'chai';
 import 'mocha';
+import {TRACE_EVENT_NAME, TRACE_EVENT_PHASE } from '../src';
 import {
   aggregate,
   Aggregations,
@@ -31,21 +32,31 @@ describe('aggregate', () => {
     let generator = new ProfileGenerator();
     let root = generator.start();
 
-    let a = generator.append(root, 100, { functionName: 'a' });
-    generator.append(a, 50, { functionName: 'b' });
-    generator.append(a, 75, { functionName: 'c' });
-    generator.append(root, 100, { functionName: 'd' });
-    let e = generator.append(root, 25, { functionName: 'e' });
-    generator.append(e, 15, { functionName: 'f' });
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    let a = generator.appendNode(root, {functionName: 'a'});
+    generator.tick(100);
+    generator.appendNode(a, {functionName: 'b'});
+    generator.tick(50);
+    generator.appendNode(a, {functionName: 'c'});
+    generator.tick(75);
+    generator.appendNode(root, {functionName: 'd'});
+    generator.tick(25);
+    let e = generator.appendNode(root, {functionName: 'e'});
+    generator.tick(25);
+    generator.appendNode(e, {functionName: 'f'});
+    generator.tick(15);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
     let json = generator.end();
 
-    let profile = new CpuProfile(json, -1, -1);
-    let locators = new LocatorGenerator().generate([
-      ['a', '.*'],
-      ['c', '.*'],
-      ['d', '.*'],
-      ['f', '.*'],
-    ]);
+    // What the call stack looks like
+    // 0    100  200  250  325  350  375  390
+    // v8-s r    r    r    r    r    r    v8-e
+    // v8-s a    a    a    d    e    e    v8-e
+    // v8-s      b    c              f    v8-e
+
+    let profile = new CpuProfile(json, generator.events, -1, -1);
+    let locators = new LocatorGenerator().generate([['a', '.*'], ['c', '.*'], ['d', '.*'], ['f', '.*']]);
     let modMatcher = new ModuleMatcher(profile.hierarchy, archive);
     let aggregations = aggregate(profile.hierarchy, locators, archive, modMatcher);
 
@@ -55,8 +66,8 @@ describe('aggregate', () => {
     expect(aggregations['c.*'].total).to.equal(75);
     expect(aggregations['c.*'].attributed).to.equal(75);
 
-    expect(aggregations['d.*'].total).to.equal(100);
-    expect(aggregations['d.*'].attributed).to.equal(100);
+    expect(aggregations['d.*'].total).to.equal(25);
+    expect(aggregations['d.*'].attributed).to.equal(25);
 
     expect(aggregations['f.*'].total).to.equal(15);
     expect(aggregations['f.*'].attributed).to.equal(15);
@@ -69,22 +80,27 @@ describe('aggregate', () => {
     let generator = new ProfileGenerator();
     let root = generator.start();
 
-    let a = generator.append(root, 100, { functionName: 'a' });
-    generator.append(a, 50, { functionName: 'b' });
-    generator.append(a, 75, { functionName: 'c' });
-    generator.append(root, 100, { functionName: 'd' });
-    let e = generator.append(root, 25, { functionName: 'e' });
-    generator.append(e, 15, { functionName: 'f' });
-    generator.append(root, 10, { functionName: 'c' });
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    let a = generator.appendNode(root, {functionName: 'a'});
+    generator.tick(100);
+    generator.appendNode(a, {functionName: 'b'});
+    generator.tick(50);
+    generator.appendNode(a, {functionName: 'c'});
+    generator.tick(75);
+    generator.appendNode(root, {functionName: 'd'});
+    generator.tick(25);
+    let e = generator.appendNode(root, {functionName: 'e'});
+    generator.tick(25);
+    generator.appendNode(e, {functionName: 'f'});
+    generator.tick(15);
+    generator.appendNode(root, {functionName: 'c'});
+    generator.tick(10);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
     let json = generator.end();
 
-    let profile = new CpuProfile(json, -1, -1);
-    let locators = new LocatorGenerator().generate([
-      ['a', '.*'],
-      ['c', '.*'],
-      ['d', '.*'],
-      ['f', '.*'],
-    ]);
+    let profile = new CpuProfile(json, generator.events, -1, -1);
+    let locators = new LocatorGenerator().generate([['a', '.*'], ['c', '.*'], ['d', '.*'], ['f', '.*']]);
     let modMatcher = new ModuleMatcher(profile.hierarchy, archive);
     let aggregations = aggregate(profile.hierarchy, locators, archive, modMatcher);
 
@@ -94,8 +110,8 @@ describe('aggregate', () => {
     expect(aggregations['c.*'].total).to.equal(85);
     expect(aggregations['c.*'].attributed).to.equal(85);
 
-    expect(aggregations['d.*'].total).to.equal(100);
-    expect(aggregations['d.*'].attributed).to.equal(100);
+    expect(aggregations['d.*'].total).to.equal(25);
+    expect(aggregations['d.*'].attributed).to.equal(25);
 
     expect(aggregations['f.*'].total).to.equal(15);
     expect(aggregations['f.*'].attributed).to.equal(15);
@@ -107,34 +123,43 @@ describe('aggregate', () => {
   it('aggregates at a module level with module heuristics', () => {
     let generator = new ProfileGenerator();
     let root = generator.start();
-    let a = generator.append(root, 100, {
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    let a = generator.appendNode(root, {
       functionName: 'a',
       lineNumber: 1,
       columnNumber: 2,
       scriptId: 1,
       url: 'https://www.example.com/a.js',
     });
-    generator.append(a, 50, {
+    generator.tick(100);
+    generator.appendNode(a, {
       functionName: 'b',
       lineNumber: 1,
       columnNumber: 6,
       scriptId: 1,
       url: 'https://www.example.com/a.js',
     });
-    generator.append(a, 75, {
+    generator.tick(50);
+    generator.appendNode(a, {
       functionName: 'c',
       lineNumber: 4,
       columnNumber: 2,
       scriptId: 1,
       url: 'https://www.example.com/a.js',
     });
-    let d = generator.append(root, 25, { functionName: 'd' });
-    generator.append(d, 15, { functionName: 'e' });
+    generator.tick(75);
+    generator.appendNode(root, {functionName: 'd'});
+    generator.tick(25);
+    generator.appendNode(root, {functionName: 'e'});
+    generator.tick(25);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
     let json = generator.end();
 
     let locators = new LocatorGenerator().generate([['.*', 'module/1'], ['.*', 'module/2']]);
 
-    let profile = new CpuProfile(json, -1, -1);
+    let profile = new CpuProfile(json, generator.events, -1, -1);
     let modMatcher = new ModuleMatcher(profile.hierarchy, archive);
     let aggregations = aggregate(profile.hierarchy, locators, archive, modMatcher);
 
@@ -144,41 +169,50 @@ describe('aggregate', () => {
     expect(aggregations['.*module/2'].attributed).to.equal(75); // c(75)
     expect(aggregations['.*module/2'].total).to.equal(75); // c(75)
 
-    expect(aggregations.unknown.total).to.equal(40); // d(25) + e(15)
-    expect(aggregations.unknown.attributed).to.equal(40); // d(25) + e(15)
+    expect(aggregations.unknown.total).to.equal(50); // d(25) + e(25)
+    expect(aggregations.unknown.attributed).to.equal(50); // d(25) + e(25)
   });
 
   it('aggregates at a module level with explicit and implicit locators', () => {
     let generator = new ProfileGenerator();
     let root = generator.start();
-    let a = generator.append(root, 100, {
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    let a = generator.appendNode(root, {
       functionName: 'a',
       lineNumber: 1,
       columnNumber: 2,
       scriptId: 1,
       url: 'https://www.example.com/a.js',
     });
-    generator.append(a, 50, {
+    generator.tick(100);
+    generator.appendNode(a, {
       functionName: 'b',
       lineNumber: 1,
       columnNumber: 6,
       scriptId: 1,
       url: 'https://www.example.com/a.js',
     });
-    generator.append(a, 75, {
+    generator.tick(50);
+    generator.appendNode(a, {
       functionName: 'c',
       lineNumber: 4,
       columnNumber: 2,
       scriptId: 1,
       url: 'https://www.example.com/a.js',
     });
-    let d = generator.append(root, 25, { functionName: 'd' });
-    generator.append(d, 15, { functionName: 'e' });
+    generator.tick(75);
+    generator.appendNode(root, {functionName: 'd'});
+    generator.tick(25);
+    generator.appendNode(root, {functionName: 'e'});
+    generator.tick(25);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
     let json = generator.end();
 
     let locators = new LocatorGenerator().generate([['.*', 'module/1']]); // module/2 is implicit
 
-    let profile = new CpuProfile(json, -1, -1);
+    let profile = new CpuProfile(json, generator.events, -1, -1);
 
     let modMatcher = new ModuleMatcher(profile.hierarchy, archive);
     addRemainingModules(locators, {}, modMatcher); // this should add module/2
@@ -190,41 +224,50 @@ describe('aggregate', () => {
     expect(aggregations['.*module/2'].attributed).to.equal(75); // c(75)
     expect(aggregations['.*module/2'].total).to.equal(75); // c(75)
 
-    expect(aggregations.unknown.total).to.equal(40); // d(25) + e(15)
-    expect(aggregations.unknown.attributed).to.equal(40); // d(25) + e(15)
+    expect(aggregations.unknown.total).to.equal(50); // d(25) + e(25)
+    expect(aggregations.unknown.attributed).to.equal(50); // d(25) + e(25)
   });
 
   it('aggregates with method name heuristics trumping automatic module heuristics', () => {
     let generator = new ProfileGenerator();
     let root = generator.start();
-    let a = generator.append(root, 100, {
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    let a = generator.appendNode(root, {
       functionName: 'a',
       lineNumber: 1,
       columnNumber: 2,
       scriptId: 1,
       url: 'https://www.example.com/a.js',
     });
-    generator.append(a, 50, {
+    generator.tick(100);
+    generator.appendNode(a, {
       functionName: 'b',
       lineNumber: 1,
       columnNumber: 6,
       scriptId: 1,
       url: 'https://www.example.com/a.js',
     });
-    generator.append(a, 75, {
+    generator.tick(50);
+    generator.appendNode(a, {
       functionName: 'c',
       lineNumber: 4,
       columnNumber: 2,
       scriptId: 1,
       url: 'https://www.example.com/a.js',
     });
-    let d = generator.append(root, 25, { functionName: 'd' });
-    generator.append(d, 15, { functionName: 'e' });
+    generator.tick(75);
+    generator.appendNode(root, {functionName: 'd'});
+    generator.tick(25);
+    generator.appendNode(root, {functionName: 'e'});
+    generator.tick(25);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
     let json = generator.end();
 
     let locators = new LocatorGenerator().generate([['a', '.*']]); // this will steal time from module/1
 
-    let profile = new CpuProfile(json, -1, -1);
+    let profile = new CpuProfile(json, generator.events, -1, -1);
 
     let modMatcher = new ModuleMatcher(profile.hierarchy, archive); // this should add module/1 & 2
     addRemainingModules(locators, {}, modMatcher);
@@ -239,8 +282,8 @@ describe('aggregate', () => {
     expect(aggregations['.*module/2'].attributed).to.equal(75); // c(75)
     expect(aggregations['.*module/2'].total).to.equal(75); // c(75)
 
-    expect(aggregations.unknown.total).to.equal(40); // d(25) + e(15)
-    expect(aggregations.unknown.attributed).to.equal(40); // d(25) + e(15)
+    expect(aggregations.unknown.total).to.equal(50); // d(25) + e(25)
+    expect(aggregations.unknown.attributed).to.equal(50); // d(25) + e(25)
   });
 });
 
@@ -254,24 +297,28 @@ describe('categorizeAggregations', () => {
     let generator = new ProfileGenerator();
     let root = generator.start();
 
-    let a = generator.append(root, 100, { functionName: 'a' });
-    generator.append(a, 50, { functionName: 'b' });
-    generator.append(a, 75, { functionName: 'c' });
-
-    let e = generator.append(root, 25, { functionName: 'e' });
-    generator.append(e, 15, { functionName: 'f' });
-
-    generator.append(root, 10, { functionName: 'c' });
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    let a = generator.appendNode(root, {functionName: 'a'});
+    generator.tick(100);
+    generator.appendNode(a, {functionName: 'b'});
+    generator.tick(50);
+    generator.appendNode(a, {functionName: 'c'});
+    generator.tick(75);
+    generator.appendNode(root, {functionName: 'd'});
+    generator.tick(25);
+    let e = generator.appendNode(root, {functionName: 'e'});
+    generator.tick(25);
+    generator.appendNode(e, {functionName: 'f'});
+    generator.tick(15);
+    generator.appendNode(root, {functionName: 'c'});
+    generator.tick(10);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
 
     let json = generator.end();
 
-    let profile = new CpuProfile(json, -1, -1);
-    let locators = new LocatorGenerator().generate([
-      ['a', '.*'],
-      ['c', '.*'],
-      ['d', '.*'],
-      ['f', '.*'],
-    ]);
+    let profile = new CpuProfile(json, generator.events, -1, -1);
+    let locators = new LocatorGenerator().generate([['a', '.*'], ['c', '.*'], ['d', '.*'], ['f', '.*']]);
     let modMatcher = new ModuleMatcher(profile.hierarchy, archive);
     aggregations = aggregate(profile.hierarchy, locators, archive, modMatcher);
   });

--- a/tests/cpu-profile-test.ts
+++ b/tests/cpu-profile-test.ts
@@ -4,9 +4,103 @@ import { expect } from 'chai';
 import 'mocha';
 import CpuProfile from '../src/trace/cpuprofile';
 
+import {FUNCTION_NAME, TRACE_EVENT_NAME, TRACE_EVENT_PHASE } from '../src';
+
+import { ProfileGenerator } from './generators';
+
 describe('CpuProfile', () => {
-  it('class exists', () => {
-    // tslint:disable:no-unused-expression
-    expect(CpuProfile).to.not.be.undefined;
+  it('expands nodes from samples separated by v8.executes', () => {
+    const generator = new ProfileGenerator();
+    const root = generator.start();
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    const a = generator.appendNode(root, {functionName: 'a'});
+    generator.tick(10);
+    generator.appendNode(a, {functionName: 'b'});
+    generator.tick(20);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
+    generator.tick(1);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(3);
+    generator.appendSample(a);
+    generator.tick(10);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
+
+    const json = generator.end();
+    const profile = new CpuProfile(json, generator.events, -1, -1);
+
+    // [root                     ]
+    // [a1 (10)       ] [a2 (10) ]
+    //         [b (20)]
+    const a1 = profile.hierarchy.children![0];
+    expect(a1.data.min).to.eq(1);
+    expect(a1.data.max).to.eq(31);
+    expect(a1.data.self).to.eq(10);
+
+    const a2 = profile.hierarchy.children![1];
+    expect(a2.data.min).to.eq(35);
+    expect(a2.data.max).to.eq(45);
+    expect(a2.data.self).to.eq(10);
+
+    const b = profile.hierarchy.children![0].children![0];
+    expect(b.data.min).to.eq(11);
+    expect(b.data.max).to.eq(31);
+    expect(b.data.self).to.eq(20);
+  });
+
+  it('handles GC and Program samples correctly', () => {
+    const generator = new ProfileGenerator();
+    const root = generator.start();
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    const a = generator.appendNode(root, {functionName: 'a'});
+    generator.tick(5);
+    generator.appendNode(root, {functionName: FUNCTION_NAME.GC});
+    generator.tick(2);
+    generator.appendSample(a);
+    generator.tick(3);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
+
+    generator.tick(1);
+    generator.appendNode(root, {functionName: FUNCTION_NAME.PROGRAM});
+    generator.tick(1);
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    generator.appendSample(a);
+    generator.tick(5);
+    generator.appendNode(root, {functionName: FUNCTION_NAME.PROGRAM});
+    generator.tick(2);
+    generator.appendSample(a);
+    generator.tick(3);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
+
+    const json = generator.end();
+    const profile = new CpuProfile(json, generator.events, -1, -1);
+
+    // [root                                                     ]
+    // [a1 (10)       ] | (1) [Program 1] (1) | [a2 (10)         ]
+    //     [GC (2)]                               [Program 2 (2)]
+    const a1 = profile.hierarchy.children![0];
+    expect(a1.data.min).to.eq(1);
+    expect(a1.data.max).to.eq(11);
+    expect(a1.data.self).to.eq(8);
+
+    const GC = profile.hierarchy.children![0].children![0];
+    expect(GC.data.min).to.eq(6);
+    expect(GC.data.max).to.eq(8);
+    expect(GC.data.self).to.eq(2);
+
+    const a2 = profile.hierarchy.children![1];
+    expect(a2.data.min).to.eq(14);
+    expect(a2.data.max).to.eq(24);
+    expect(a2.data.self).to.eq(8);
+
+    const program2 = profile.hierarchy.children![1].children![0];
+    expect(program2.data.min).to.eq(19);
+    expect(program2.data.max).to.eq(21);
+    expect(program2.data.self).to.eq(2);
   });
 });


### PR DESCRIPTION
**Changes**
- Expands Chrome's collapsed call tree trace format into a full profile, with one node per discrete function slice across time.
- Function durations now continue until one sample after they are last seen. We now align with Chrome dev tools on this. The old logic was to stretch them from one sample before they are first seen instead.
- GC and Program function slices are placed as children of the last seen normal function sample.
- Only samples occurring between V8.execute start-->end events are processed. Function slices are terminated by V8.execute end events.
- The test sample generator class has been rewritten to make it easier to add time deltas after a dummy sample.
- Adds an export function to write out expanded function slices as User Timing events, so they can be visualized in chrome://tracing. Note: this feature is still in beta and its use is commented out by default at the moment. This will be integrated into a flag later.